### PR TITLE
Create deploy setting for Fabric3 

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -1,0 +1,36 @@
+from fabric.api import local, run, cd, env, settings, shell_env
+
+env.use_ssh_config = True
+env.user = 'pyconkr'
+env.hosts = ['pythonkorea1']
+
+
+def deploy(target='dev-seminar', sha1=None):
+    if sha1 is None:
+        # get current working git sha1
+        sha1 = local('git rev-parse HEAD', capture=True)
+
+    # server code reset to current working sha1
+    home_dir = '/home/pyconkr/{target}.pycon.kr/'.format(target=target)
+
+    if target == 'dev-seminar':
+        python_env = '/home/pyconkr/.pyenv/versions/dev-seminar'
+        django_settings_module='seminar.settings.dev'
+    elif target == 'seminar':
+        python_env = '/home/pyconkr/.pyenv/versions/seminar'
+        django_settings_module='seminar.settings.production'
+    else:
+        raise Exception
+
+    with settings(cd(home_dir), shell_env(DJANGO_SETTINGS_MODULE=django_settings_module)):
+        run('git fetch --all -p')
+        run('git reset --hard ' + sha1)
+
+        # run('bower install')
+        run('%s/bin/pip install -r requirements.txt' % python_env)
+        # run('%s/bin/python manage.py compilemessages' % python_env)
+        run('%s/bin/python manage.py migrate' % python_env)
+        # run('%s/bin/python manage.py collectstatic --noinput' % python_env)
+
+        # worker reload
+        run('echo r > /home/pyconkr/run/%s.fifo' % target)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 pytest-django==3.1.2
 codecov==2.0.9
 flake8==3.4.1
+Fabric3==1.13.1.post1


### PR DESCRIPTION
[PyCon.KR 2017 - fabfile.py](https://github.com/pythonkr/pyconkr-2017/blob/master/fabfile.py) 파일을 따와 Fabric의 Python 3 호환 버전인 [Fabric3](https://github.com/mathiasertl/fabric)을 이용해서 배포 설정을 했습니다. 

현재 PR 올려놓은 `feature/deploy` 브랜치가 제 Fork repo 기준으로 돼있어서, 테스트하는 방법은 pythonkr의 origin repo에서 수정하고 fabfile.py을 복사해서 fab deploy 해보시면 개발 서버에 배포할 수 있습니다.

`fab deploy` => 개발 서버 배포
`fab deploy:seminar` => 실 서버 배포 (아직 준비가 안 돼서 동작하지 않습니다)

`bower install`, `manage.py compilemessages`, `manage.py collectstatic` 명령어 들은 아직 준비가 안 된 것 같아 주석처리 해놓았습니다.
